### PR TITLE
feat(mastodon): Add OAuth 2.0 module with Scopes, Metadata, and PKCE

### DIFF
--- a/packages/social-mastodon-v1/lib/dune
+++ b/packages/social-mastodon-v1/lib/dune
@@ -6,4 +6,7 @@
   social-core
   yojson
   digestif
-  base64))
+  base64
+  uri
+  ptime
+  ptime.clock.os))


### PR DESCRIPTION
## Summary

Add comprehensive OAuth 2.0 support to the Mastodon package (`social-mastodon-v1`), making the SDK "batteries included" for OAuth token acquisition flows.

### Changes

- **New `OAuth` module** at top-level (outside the `Make` functor):
  - `Scopes` submodule with `read`, `write`, `all` scope lists plus granular options
  - `Metadata` submodule with platform info (PKCE support, no token expiry, federated)
  - `Pkce` submodule with `generate_code_verifier` and `generate_code_challenge` (S256)
  - `get_authorization_url` for generating instance-specific OAuth URLs
  - `OAuth.Make` functor for HTTP-dependent operations:
    - `register_app` for per-instance app registration (unique to Mastodon)
    - `exchange_code` for token exchange with optional PKCE
    - `revoke_token` for token revocation

- **Updated dependencies** in dune file (uri, ptime)
- **Marked legacy PKCE functions** as `@deprecated`

### Mastodon OAuth Quirks Documented

- **Federated model**: Each instance requires separate app registration
- **Per-instance client credentials**: Must call `register_app` once per instance
- **Tokens never expire**: No refresh needed, tokens valid until revoked
- **Full PKCE support**: S256 method supported

### Usage Example

```ocaml
(* 1. Register app with instance (one-time per instance) *)
module OAuthClient = Mastodon_v1.OAuth.Make(MyHttpClient)

OAuthClient.register_app
  ~instance_url:"https://mastodon.social"
  ~client_name:"MyApp"
  ~redirect_uris:"https://example.com/callback"
  (fun (client_id, client_secret) ->
    (* Store these securely per instance *)
    
    (* 2. Generate authorization URL *)
    let code_verifier = Mastodon_v1.OAuth.Pkce.generate_code_verifier () in
    let code_challenge = Mastodon_v1.OAuth.Pkce.generate_code_challenge code_verifier in
    
    let auth_url = Mastodon_v1.OAuth.get_authorization_url
      ~instance_url:"https://mastodon.social"
      ~client_id
      ~redirect_uri:"https://example.com/callback"
      ~code_challenge
      ()
    in
    (* Redirect user to auth_url *)
    
    (* 3. After callback, exchange code *)
    OAuthClient.exchange_code
      ~instance_url:"https://mastodon.social"
      ~client_id ~client_secret
      ~redirect_uri:"https://example.com/callback"
      ~code:"code_from_callback"
      ~code_verifier
      (fun credentials -> (* Store and use credentials *))
      (fun error -> (* Handle error *))
  )
  (fun error -> (* Handle registration error *))
```

### Design

Follows the design outlined in [ADR-051](https://github.com/makerprism/feedmansion/blob/main/docs/adr/051-oauth-sdk-upstream.md).

Closes #4