### PR TITLE
fix: add missing ptime and uri dependencies to social-mastodon-v1

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -95,7 +95,9 @@
   (social-core (= :version))
   yojson
   digestif
-  base64))
+  base64
+  uri
+  ptime))
 
 (package
  (name social-facebook-graph-v21)


### PR DESCRIPTION
The library uses `ptime.clock.os` and `uri` in its dune file but these were not declared in the package dependencies in dune-project, causing build failures for consumers when the lock file is generated.