### PR TITLE
fix: standardize ensure_valid_token error types across all providers

### DIFF
--- a/packages/social-facebook-graph-v21/lib/facebook_graph_v21.ml
+++ b/packages/social-facebook-graph-v21/lib/facebook_graph_v21.ml
@@ -632,14 +632,14 @@ module Make (Config : CONFIG) = struct
           (* Token expiring soon - Facebook requires re-authentication *)
           Config.update_health_status ~account_id ~status:"token_expired" 
             ~error_message:(Some "Access token expired - please reconnect")
-            (fun () -> on_error "Facebook Page token expired - please reconnect")
-            on_error
+            (fun () -> on_error (Error_types.Auth_error Error_types.Token_expired))
+            (fun _ -> on_error (Error_types.Auth_error Error_types.Token_expired))
         else
           (* Token still valid *)
           Config.update_health_status ~account_id ~status:"healthy" ~error_message:None
             (fun () -> on_success creds.access_token)
-            on_error)
-      on_error
+            (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
+      (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err)))
   
   (** Upload photo to Facebook Page with optional alt text *)
   let upload_photo ~page_id ~page_access_token ~image_url ~alt_text on_result =
@@ -836,8 +836,7 @@ module Make (Config : CONFIG) = struct
                   (fun video_id -> on_result (Error_types.Success video_id))
                   (fun err -> on_result (Error_types.Failure (Error_types.Internal_error err))))
               (fun err -> on_result (Error_types.Failure (Error_types.Internal_error err))))
-          (fun err -> on_result (Error_types.Failure 
-            (Error_types.Auth_error (Error_types.Refresh_failed err))))
+          (fun err -> on_result (Error_types.Failure err))
   
   (** {1 Facebook Page Stories} *)
   
@@ -1044,8 +1043,7 @@ module Make (Config : CONFIG) = struct
                 | Ok story_id -> on_result (Error_types.Success story_id)
                 | Error e -> on_result (Error_types.Failure e)))
           (fun err -> on_result (Error_types.Failure (Error_types.Internal_error err))))
-      (fun err -> on_result (Error_types.Failure 
-        (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error_types.Failure err))
   
   (** Post video story to Facebook Page (high-level)
       
@@ -1063,8 +1061,7 @@ module Make (Config : CONFIG) = struct
                 | Ok story_id -> on_result (Error_types.Success story_id)
                 | Error e -> on_result (Error_types.Failure e)))
           (fun err -> on_result (Error_types.Failure (Error_types.Internal_error err))))
-      (fun err -> on_result (Error_types.Failure 
-        (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error_types.Failure err))
   
   (** Detect media type from URL extension *)
   let detect_media_type url =
@@ -1192,8 +1189,7 @@ module Make (Config : CONFIG) = struct
                                 (parse_api_error ~status_code:response.status ~response_body:response.body)))
                           (fun err -> on_result (Error_types.Failure (Error_types.Internal_error err)))))
                   (fun err -> on_result (Error_types.Failure (Error_types.Internal_error err))))
-              (fun err -> on_result (Error_types.Failure 
-                (Error_types.Auth_error (Error_types.Refresh_failed err))))
+              (fun err -> on_result (Error_types.Failure err))
   
   (** Post thread (Facebook doesn't support threads, posts only first item with warning) *)
   let post_thread ~account_id ~texts ~media_urls_per_post ?(alt_texts_per_post=[]) on_result =

--- a/packages/social-facebook-graph-v21/test/test_facebook.ml
+++ b/packages/social-facebook-graph-v21/test/test_facebook.ml
@@ -250,7 +250,7 @@ let test_ensure_valid_token_fresh () =
       match Mock_config.get_health_status "test_account" with
       | Some (_, "healthy", None) -> print_endline "✓ Ensure valid token (fresh)"
       | _ -> failwith "Health status not updated correctly")
-    (fun err -> failwith ("Ensure valid token failed: " ^ err))
+    (fun err -> failwith ("Ensure valid token failed: " ^ Error_types.error_to_string err))
 
 (** Test: Ensure valid token (expired token) *)
 let test_ensure_valid_token_expired () =
@@ -276,7 +276,8 @@ let test_ensure_valid_token_expired () =
   Facebook.ensure_valid_token ~account_id:"test_account"
     (fun _ -> failwith "Should fail with expired token")
     (fun err ->
-      assert (string_contains err "expired");
+      let err_str = Error_types.error_to_string err in
+      assert (string_contains err_str "expired");
       (* Verify health status was updated *)
       match Mock_config.get_health_status "test_account" with
       | Some (_, "token_expired", _) -> print_endline "✓ Ensure valid token (expired)"

--- a/packages/social-instagram-graph-v21/lib/instagram_graph_v21.ml
+++ b/packages/social-instagram-graph-v21/lib/instagram_graph_v21.ml
@@ -721,22 +721,22 @@ module Make (Config : CONFIG) = struct
                 (fun () ->
                   Config.update_health_status ~account_id ~status:"healthy" ~error_message:None
                     (fun () -> on_success refreshed_creds.access_token)
-                    on_error)
+                    (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
                 (fun err ->
                   (* Failed to update credentials in DB *)
-                  on_error (Printf.sprintf "Failed to save refreshed token: %s" err)))
+                  on_error (Error_types.Network_error (Error_types.Connection_failed (Printf.sprintf "Failed to save refreshed token: %s" err)))))
             (fun refresh_err ->
               (* Token refresh failed - mark as expired and ask user to reconnect *)
               Config.update_health_status ~account_id ~status:"token_expired" 
                 ~error_message:(Some "Access token expired - please reconnect")
-                (fun () -> on_error (Printf.sprintf "Token refresh failed: %s. Please reconnect your Instagram account." refresh_err))
-                on_error)
+                (fun () -> on_error (Error_types.Auth_error (Error_types.Refresh_failed refresh_err)))
+                (fun _ -> on_error (Error_types.Auth_error (Error_types.Refresh_failed refresh_err))))
         else
           (* Token is still valid *)
           Config.update_health_status ~account_id ~status:"healthy" ~error_message:None
             (fun () -> on_success creds.access_token)
-            on_error)
-      on_error
+            (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
+      (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err)))
   
   (** Media type detection from URL *)
   let detect_media_type url =
@@ -1075,8 +1075,7 @@ module Make (Config : CONFIG) = struct
                           (Error_types.Internal_error err))))
                     (fun err -> on_result (Error_types.Failure 
                       (Error_types.Internal_error err))))
-                (fun err -> on_result (Error_types.Failure 
-                  (Error_types.Auth_error (Error_types.Refresh_failed err))))
+                (fun err -> on_result (Error_types.Failure err))
             else
               (* Single image or video post *)
               ensure_valid_token ~account_id
@@ -1115,8 +1114,7 @@ module Make (Config : CONFIG) = struct
                               | Error e -> on_result (Error_types.Failure e))))
                     (fun err -> on_result (Error_types.Failure 
                       (Error_types.Internal_error err))))
-                (fun err -> on_result (Error_types.Failure 
-                  (Error_types.Auth_error (Error_types.Refresh_failed err))))
+                (fun err -> on_result (Error_types.Failure err))
   
   (** Post Reel (short-form video) *)
   let post_reel ~account_id ~text ~video_url ?(alt_text=None) on_result =
@@ -1142,8 +1140,7 @@ module Make (Config : CONFIG) = struct
                     | Error e -> on_result (Error_types.Failure e)))
               (fun err -> on_result (Error_types.Failure 
                 (Error_types.Internal_error err))))
-          (fun err -> on_result (Error_types.Failure 
-            (Error_types.Auth_error (Error_types.Refresh_failed err))))
+          (fun err -> on_result (Error_types.Failure err))
   
   (** {1 Instagram Stories} *)
   
@@ -1271,8 +1268,7 @@ module Make (Config : CONFIG) = struct
                 | Error e -> on_result (Error_types.Failure e)))
           (fun err -> on_result (Error_types.Failure 
             (Error_types.Internal_error err))))
-      (fun err -> on_result (Error_types.Failure 
-        (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error_types.Failure err))
   
   (** Post video story to Instagram
       
@@ -1309,8 +1305,7 @@ module Make (Config : CONFIG) = struct
                 | Error e -> on_result (Error_types.Failure e)))
           (fun err -> on_result (Error_types.Failure 
             (Error_types.Internal_error err))))
-      (fun err -> on_result (Error_types.Failure 
-        (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error_types.Failure err))
   
   (** Post story to Instagram (auto-detect media type)
       

--- a/packages/social-linkedin-v2/lib/linkedin_v2.ml
+++ b/packages/social-linkedin-v2/lib/linkedin_v2.ml
@@ -581,8 +581,8 @@ module Make (Config : CONFIG) = struct
           | None ->
               Config.update_health_status ~account_id ~status:"token_expired" 
                 ~error_message:(Some "Token expired - please reconnect (LinkedIn tokens last 60 days)")
-                (fun () -> on_error "LinkedIn token expired - please reconnect your account")
-                on_error
+                (fun () -> on_error (Error_types.Auth_error Error_types.Token_expired))
+                (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err)))
           | Some refresh_token ->
               let client_id = Config.get_env "LINKEDIN_CLIENT_ID" |> Option.value ~default:"" in
               let client_secret = Config.get_env "LINKEDIN_CLIENT_SECRET" |> Option.value ~default:"" in
@@ -600,8 +600,8 @@ module Make (Config : CONFIG) = struct
                     (fun () ->
                       Config.update_health_status ~account_id ~status:"healthy" ~error_message:None
                         (fun () -> on_success new_access)
-                        on_error)
-                    on_error)
+                        (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
+                    (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
                 (fun err ->
                   let user_friendly_error = 
                     if String.length err > 100 && 
@@ -613,15 +613,15 @@ module Make (Config : CONFIG) = struct
                   in
                   Config.update_health_status ~account_id ~status:"refresh_failed" 
                     ~error_message:(Some user_friendly_error)
-                    (fun () -> on_error user_friendly_error)
-                    on_error)
+                    (fun () -> on_error (Error_types.Auth_error (Error_types.Refresh_failed user_friendly_error)))
+                    (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
         ) else (
           (* Token still valid *)
           Config.update_health_status ~account_id ~status:"healthy" ~error_message:None
             (fun () -> on_success creds.access_token)
-            on_error
+            (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err)))
         ))
-      on_error
+      (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err)))
   
   (** Get person URN for posting *)
   let get_person_urn ~access_token on_success on_error =
@@ -873,12 +873,11 @@ module Make (Config : CONFIG) = struct
                             ~status_code:response.status ~body:response.body)))
                       (fun err -> on_result (Error_types.Failure (Error_types.Network_error 
                         (Error_types.Connection_failed err)))))
-                  (fun err -> on_result (Error_types.Failure (Error_types.Network_error 
-                    (Error_types.Connection_failed err)))))
-              (fun err -> on_result (Error_types.Failure (Error_types.Network_error 
-                (Error_types.Connection_failed err)))))
-          (fun err -> on_result (Error_types.Failure (Error_types.Auth_error 
-            (Error_types.Refresh_failed err))))
+                   (fun err -> on_result (Error_types.Failure (Error_types.Network_error 
+                     (Error_types.Connection_failed err)))))
+               (fun err -> on_result (Error_types.Failure (Error_types.Network_error 
+                 (Error_types.Connection_failed err)))))
+           (fun err -> on_result (Error_types.Failure err))
   
   (** Post thread (LinkedIn doesn't support threads, posts only first item)
       
@@ -1089,7 +1088,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** {1 Posts API} *)
   
@@ -1139,7 +1138,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Get user's posts with pagination
       
@@ -1222,7 +1221,7 @@ module Make (Config : CONFIG) = struct
                   on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
               (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
           (fun err -> on_result (Error (Error_types.Internal_error err))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** {1 Scroller Pattern for Pagination} *)
   
@@ -1350,7 +1349,7 @@ module Make (Config : CONFIG) = struct
               else
                 on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
             (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** {1 Search API (FINDER Pattern)} *)
   
@@ -1445,7 +1444,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Create a scroller for post search *)
   let create_search_scroller ~account_id ?keywords ?author ?(page_size=10) () =
@@ -1524,7 +1523,7 @@ module Make (Config : CONFIG) = struct
                   on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
               (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
           (fun err -> on_result (Error (Error_types.Internal_error err))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Unlike a post
       
@@ -1555,7 +1554,7 @@ module Make (Config : CONFIG) = struct
                   on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
               (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
           (fun err -> on_result (Error (Error_types.Internal_error err))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Comment on a post
       
@@ -1601,7 +1600,7 @@ module Make (Config : CONFIG) = struct
                   on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
               (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
           (fun err -> on_result (Error (Error_types.Internal_error err))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Get comments on a post
       
@@ -1664,7 +1663,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Get engagement statistics for a post
       
@@ -1701,5 +1700,5 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
 end

--- a/packages/social-linkedin-v2/test/test_linkedin.ml
+++ b/packages/social-linkedin-v2/test/test_linkedin.ml
@@ -320,7 +320,7 @@ let test_ensure_valid_token_fresh () =
       match Mock_config.get_health_status "test_account" with
       | Some (_, "healthy", None) -> print_endline "✓ Ensure valid token (fresh)"
       | _ -> failwith "Health status not updated correctly")
-    (fun err -> failwith ("Ensure valid token failed: " ^ err))
+    (fun err -> failwith ("Ensure valid token failed: " ^ Error_types.error_to_string err))
 
 (** Test: Get profile *)
 let test_get_profile () =
@@ -867,7 +867,7 @@ let test_expired_token_detection () =
       print_endline "✓ Expired token detection and refresh")
     (fun err ->
       (* Or fail gracefully if refresh not enabled *)
-      assert (String.length err > 0);
+      assert (String.length (Error_types.error_to_string err) > 0);
       print_endline "✓ Expired token detection and refresh")
 
 (** Test: OAuth state CSRF protection *)

--- a/packages/social-mastodon-v1/lib/mastodon_v1.ml
+++ b/packages/social-mastodon-v1/lib/mastodon_v1.ml
@@ -583,14 +583,14 @@ module Make (Config : CONFIG) = struct
               (fun () ->
                 Config.update_health_status ~account_id ~status:"healthy" ~error_message:None
                   (fun () -> on_success mastodon_creds)
-                  on_error)
+                  (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
               (fun err ->
                 Config.update_health_status ~account_id ~status:"invalid_token" 
                   ~error_message:(Some err)
-                  (fun () -> on_error err)
-                  on_error))
-          on_error)
-      on_error
+                  (fun () -> on_error (Error_types.Auth_error Error_types.Token_invalid))
+                  (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err)))))
+          (fun err -> on_error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err)))
   
   (** Post single status with full options *)
   let post_single 
@@ -745,7 +745,7 @@ module Make (Config : CONFIG) = struct
                   on_result (Error_types.Failure (parse_api_error ~status_code:response.status ~response_body:response.body)))
               on_media_error)
           on_media_error)
-      (fun err -> on_result (Error_types.Failure (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error_types.Failure err))
   
   (** Post thread with full options *)
   let post_thread 
@@ -914,7 +914,7 @@ module Make (Config : CONFIG) = struct
           in
           
           post_statuses_seq posts_with_media_and_alt 0 None [])
-      (fun err -> on_result (Error_types.Failure (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error_types.Failure err))
   
   (** Validate content for Mastodon 
       Note: The actual character limit may vary by instance. 
@@ -980,9 +980,9 @@ module Make (Config : CONFIG) = struct
             if response.status >= 200 && response.status < 300 then
               on_success ()
             else
-              on_error (Printf.sprintf "Delete failed (%d): %s" response.status response.body))
-          on_error)
-      on_error
+              on_error (parse_api_error ~status_code:response.status ~response_body:response.body))
+          (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
+      (fun err -> on_error err)
   
   (** Edit a status *)
   let edit_status
@@ -1057,11 +1057,11 @@ module Make (Config : CONFIG) = struct
                 let edited_id = json |> Yojson.Basic.Util.member "id" |> Yojson.Basic.Util.to_string in
                 on_success edited_id
               with e ->
-                on_error (Printf.sprintf "Failed to parse edit response: %s" (Printexc.to_string e))
+                on_error (Error_types.Internal_error (Printf.sprintf "Failed to parse edit response: %s" (Printexc.to_string e)))
             else
-              on_error (Printf.sprintf "Edit failed (%d): %s" response.status response.body))
-          on_error)
-      on_error
+              on_error (parse_api_error ~status_code:response.status ~response_body:response.body))
+          (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
+      (fun err -> on_error err)
   
   (** Favorite a status *)
   let favorite_status ~account_id ~status_id on_result =
@@ -1079,7 +1079,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~response_body:response.body)))
           (fun err -> on_result (Error (Error_types.Internal_error err))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Unfavorite a status *)
   let unfavorite_status ~account_id ~status_id on_result =
@@ -1097,7 +1097,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~response_body:response.body)))
           (fun err -> on_result (Error (Error_types.Internal_error err))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Boost (reblog) a status *)
   let boost_status ~account_id ~status_id ?(visibility=None) on_result =
@@ -1123,7 +1123,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~response_body:response.body)))
           (fun err -> on_result (Error (Error_types.Internal_error err))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Unboost (unreblog) a status *)
   let unboost_status ~account_id ~status_id on_result =
@@ -1141,7 +1141,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~response_body:response.body)))
           (fun err -> on_result (Error (Error_types.Internal_error err))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Bookmark a status *)
   let bookmark_status ~account_id ~status_id on_result =
@@ -1159,7 +1159,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~response_body:response.body)))
           (fun err -> on_result (Error (Error_types.Internal_error err))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Unbookmark a status *)
   let unbookmark_status ~account_id ~status_id on_result =
@@ -1177,7 +1177,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~response_body:response.body)))
           (fun err -> on_result (Error (Error_types.Internal_error err))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Register an application with a Mastodon instance *)
   let register_app ~instance_url ~client_name ~redirect_uris ~scopes ~website on_result =
@@ -1323,6 +1323,6 @@ module Make (Config : CONFIG) = struct
                 (* Network errors should also not fail the disconnect flow *)
                 on_result (Ok ())  (* Continue with disconnect even if revocation failed *)
               ))
-          (fun err -> on_result (Error (Error_types.Internal_error err))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+          (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err)))))
+      (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err))))
 end

--- a/packages/social-mastodon-v1/test/test_mastodon_v1.ml
+++ b/packages/social-mastodon-v1/test/test_mastodon_v1.ml
@@ -201,7 +201,7 @@ let test_delete_status () =
       success_called := true;
       Printf.printf "✓\n")
     (fun err ->
-      Printf.printf "✗ Error: %s\n" err;
+      Printf.printf "✗ Error: %s\n" (Error_types.error_to_string err);
       assert false);
   assert !success_called
 
@@ -217,7 +217,7 @@ let test_edit_status () =
       success_called := true;
       Printf.printf "✓ (edited_id: %s)\n" edited_id)
     (fun err ->
-      Printf.printf "✗ Error: %s\n" err;
+      Printf.printf "✗ Error: %s\n" (Error_types.error_to_string err);
       assert false);
   assert !success_called
 

--- a/packages/social-pinterest-v5/lib/pinterest_v5.ml
+++ b/packages/social-pinterest-v5/lib/pinterest_v5.ml
@@ -401,8 +401,8 @@ module Make (Config : CONFIG) = struct
       (fun creds ->
         Config.update_health_status ~account_id ~status:"healthy" ~error_message:None
           (fun () -> on_success creds.access_token)
-          on_error)
-      on_error
+          (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
+      (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err)))
   
   (** Get user's default board *)
   let get_default_board ~access_token on_success on_error =
@@ -525,7 +525,7 @@ module Make (Config : CONFIG) = struct
                       (fun err -> on_result (Error_types.Failure (Error_types.Internal_error err))))
                   (fun err -> on_result (Error_types.Failure (Error_types.Internal_error err))))
               (fun err -> on_result (Error_types.Failure (Error_types.Internal_error err))))
-          (fun err -> on_result (Error_types.Failure (Error_types.Auth_error (Error_types.Refresh_failed err))))
+          (fun err -> on_result (Error_types.Failure err))
   
   (** Post thread (Pinterest doesn't support threads, posts only first item) *)
   let post_thread ~account_id ~texts ~media_urls_per_post ?(alt_texts_per_post=[]) on_result =

--- a/packages/social-tiktok-v1/lib/tiktok_v1.ml
+++ b/packages/social-tiktok-v1/lib/tiktok_v1.ml
@@ -613,8 +613,8 @@ module Make (Config : CONFIG) = struct
           | None ->
               Config.update_health_status ~account_id ~status:"token_expired"
                 ~error_message:(Some "No refresh token available")
-                (fun () -> on_error "No refresh token - please reconnect TikTok account")
-                on_error
+                (fun () -> on_error (Error_types.Auth_error Error_types.Missing_credentials))
+                (fun _ -> on_error (Error_types.Auth_error Error_types.Missing_credentials))
           | Some rt ->
               refresh_access_token ~refresh_token:rt
                 (fun (new_access, new_refresh, expires_at) ->
@@ -628,18 +628,18 @@ module Make (Config : CONFIG) = struct
                     (fun () ->
                       Config.update_health_status ~account_id ~status:"healthy" ~error_message:None
                         (fun () -> on_success new_access)
-                        on_error)
-                    on_error)
+                        (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
+                    (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
                 (fun err ->
                   Config.update_health_status ~account_id ~status:"refresh_failed"
                     ~error_message:(Some err)
-                    (fun () -> on_error err)
-                    on_error)
+                    (fun () -> on_error (Error_types.Auth_error (Error_types.Refresh_failed err)))
+                    (fun _ -> on_error (Error_types.Auth_error (Error_types.Refresh_failed err))))
         else
           Config.update_health_status ~account_id ~status:"healthy" ~error_message:None
             (fun () -> on_success creds.access_token)
-            on_error)
-      on_error
+            (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
+      (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err)))
   
   (** Query creator info to get available privacy options *)
   let get_creator_info ~account_id on_result =
@@ -659,7 +659,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~response_body:response.body)))
           (fun err -> on_result (Error (Error_types.Internal_error err))))
-      (fun err -> on_result (Error (Error_types.Internal_error err)))
+      (fun err -> on_result (Error err))
   
   (** Initialize video upload and get upload URL *)
   let init_video_upload ~account_id ~post_info ~video_size on_result =
@@ -694,7 +694,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~response_body:response.body)))
           (fun err -> on_result (Error (Error_types.Internal_error err))))
-      (fun err -> on_result (Error (Error_types.Internal_error err)))
+      (fun err -> on_result (Error err))
   
   (** Upload video content to the upload URL *)
   let upload_video_chunk ~upload_url ~video_content on_result =
@@ -733,7 +733,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~response_body:response.body)))
           (fun err -> on_result (Error (Error_types.Internal_error err))))
-      (fun err -> on_result (Error (Error_types.Internal_error err)))
+      (fun err -> on_result (Error err))
   
   (** Post a video to TikTok (high-level function)
       

--- a/packages/social-twitter-v2/lib/twitter_v2.ml
+++ b/packages/social-twitter-v2/lib/twitter_v2.ml
@@ -566,8 +566,8 @@ module Make (Config : CONFIG) = struct
           | None ->
               Config.update_health_status ~account_id ~status:"token_expired" 
                 ~error_message:(Some "No refresh token available")
-                (fun () -> on_error "No refresh token available - please reconnect")
-                on_error
+                (fun () -> on_error (Error_types.Auth_error Error_types.Missing_credentials))
+                (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err)))
           | Some refresh_token ->
               let client_id = Config.get_env "TWITTER_CLIENT_ID" |> Option.value ~default:"" in
               let client_secret = Config.get_env "TWITTER_CLIENT_SECRET" |> Option.value ~default:"" in
@@ -585,19 +585,19 @@ module Make (Config : CONFIG) = struct
                     (fun () ->
                       Config.update_health_status ~account_id ~status:"healthy" ~error_message:None
                         (fun () -> on_success new_access)
-                        on_error)
-                    on_error)
+                        (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
+                    (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
                 (fun err ->
                   Config.update_health_status ~account_id ~status:"refresh_failed" 
                     ~error_message:(Some err)
-                    (fun () -> on_error err)
-                    on_error)
+                    (fun () -> on_error (Error_types.Auth_error (Error_types.Refresh_failed err)))
+                    (fun err2 -> on_error (Error_types.Network_error (Error_types.Connection_failed err2))))
         else
           (* Token still valid *)
           Config.update_health_status ~account_id ~status:"healthy" ~error_message:None
             (fun () -> on_success creds.access_token)
-            on_error)
-      on_error
+            (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
+      (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err)))
   
   (** Update media metadata with alt text using X API v2 
       
@@ -923,12 +923,11 @@ module Make (Config : CONFIG) = struct
                             ~status_code:response.status ~body:response.body)))
                       (fun err -> on_result (Error_types.Failure (Error_types.Network_error 
                         (Error_types.Connection_failed err)))))
-                  (fun err -> on_result (Error_types.Failure (Error_types.Network_error 
+                   (fun err -> on_result (Error_types.Failure (Error_types.Network_error 
                     (Error_types.Connection_failed err)))))
-              (fun err -> on_result (Error_types.Failure (Error_types.Auth_error 
-                (Error_types.Refresh_failed err))))
+              (fun err -> on_result (Error_types.Failure err))
   
-  (** Post single tweet with pre-uploaded media IDs 
+  (** Post single tweet with pre-uploaded media IDs
       
       This function is for when media has already been uploaded to Twitter
       and you have the media_ids. Use this when the backend handles media
@@ -987,12 +986,11 @@ module Make (Config : CONFIG) = struct
                     else
                       on_result (Error_types.Failure (parse_api_error 
                         ~status_code:response.status ~body:response.body)))
-                  (fun err -> on_result (Error_types.Failure (Error_types.Network_error 
+                   (fun err -> on_result (Error_types.Failure (Error_types.Network_error 
                     (Error_types.Connection_failed err)))))
-              (fun err -> on_result (Error_types.Failure (Error_types.Auth_error 
-                (Error_types.Refresh_failed err))))
+              (fun err -> on_result (Error_types.Failure err))
   
-  (** Post thread with pre-uploaded media IDs 
+  (** Post thread with pre-uploaded media IDs
       
       Each text gets paired with its corresponding media_ids list.
       The first tweet in the thread can have media, subsequent tweets
@@ -1110,8 +1108,7 @@ module Make (Config : CONFIG) = struct
             in
             
             post_tweets_seq texts media_ids_per_post None [])
-          (fun err -> on_result (Error_types.Failure (Error_types.Auth_error 
-            (Error_types.Refresh_failed err))))
+          (fun err -> on_result (Error_types.Failure err))
   
   (** Post thread with media URLs
       
@@ -1298,8 +1295,7 @@ module Make (Config : CONFIG) = struct
             in
             
             post_tweets_seq texts media_with_alt_per_post None [])
-          (fun err -> on_result (Error_types.Failure (Error_types.Auth_error 
-            (Error_types.Refresh_failed err))))
+          (fun err -> on_result (Error_types.Failure err))
   
   (** Delete a tweet
       
@@ -1338,8 +1334,7 @@ module Make (Config : CONFIG) = struct
                 ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error_types.Failure (Error_types.Network_error 
             (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error_types.Failure (Error_types.Auth_error 
-        (Error_types.Refresh_failed err))))
+              (fun err -> on_result (Error_types.Failure err))
   
   (** Get a tweet by ID with optional expansions and fields *)
   let get_tweet ~account_id ~tweet_id ?(expansions=[]) ?(tweet_fields=[]) () on_result =
@@ -1373,7 +1368,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Search recent tweets *)
   let search_tweets ~account_id ~query ?(max_results=10) ?(next_token=None) ?(expansions=[]) ?(tweet_fields=[]) () on_result =
@@ -1410,7 +1405,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Get user timeline (tweets by user ID) *)
   let get_user_timeline ~account_id ~user_id ?(max_results=10) ?(pagination_token=None) ?(expansions=[]) ?(tweet_fields=[]) () on_result =
@@ -1446,7 +1441,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Get authenticated user's info *)
   let get_me ~account_id ?(user_fields=[]) () on_result =
@@ -1476,7 +1471,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Get mentions timeline for authenticated user *)
   let get_mentions_timeline ~account_id ?(max_results=10) ?(pagination_token=None) ?(expansions=[]) ?(tweet_fields=[]) () on_result =
@@ -1522,7 +1517,7 @@ module Make (Config : CONFIG) = struct
                   (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err))))
               with e ->
                 on_result (Error (Error_types.Internal_error (Printf.sprintf "Failed to parse user ID: %s" (Printexc.to_string e))))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Get home timeline (reverse chronological timeline of tweets from followed users) 
       Note: This endpoint requires OAuth 2.0 with user context *)
@@ -1569,7 +1564,7 @@ module Make (Config : CONFIG) = struct
                   (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err))))
               with e ->
                 on_result (Error (Error_types.Internal_error (Printf.sprintf "Failed to parse user ID: %s" (Printexc.to_string e))))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Get user by ID *)
   let get_user_by_id ~account_id ~user_id ?(user_fields=[]) () on_result =
@@ -1599,7 +1594,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Get user by username *)
   let get_user_by_username ~account_id ~username ?(user_fields=[]) () on_result =
@@ -1629,7 +1624,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Follow a user *)
   let follow_user ~account_id ~target_user_id on_result =
@@ -1663,7 +1658,7 @@ module Make (Config : CONFIG) = struct
                   (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err))))
               with e ->
                 on_result (Error (Error_types.Internal_error (Printf.sprintf "Failed to parse user ID: %s" (Printexc.to_string e))))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Unfollow a user *)
   let unfollow_user ~account_id ~target_user_id on_result =
@@ -1693,7 +1688,7 @@ module Make (Config : CONFIG) = struct
                   (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err))))
               with e ->
                 on_result (Error (Error_types.Internal_error (Printf.sprintf "Failed to parse user ID: %s" (Printexc.to_string e))))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Block a user *)
   let block_user ~account_id ~target_user_id on_result =
@@ -1726,7 +1721,7 @@ module Make (Config : CONFIG) = struct
                   (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err))))
               with e ->
                 on_result (Error (Error_types.Internal_error (Printf.sprintf "Failed to parse user ID: %s" (Printexc.to_string e))))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Unblock a user *)
   let unblock_user ~account_id ~target_user_id on_result =
@@ -1756,7 +1751,7 @@ module Make (Config : CONFIG) = struct
                   (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err))))
               with e ->
                 on_result (Error (Error_types.Internal_error (Printf.sprintf "Failed to parse user ID: %s" (Printexc.to_string e))))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Mute a user *)
   let mute_user ~account_id ~target_user_id on_result =
@@ -1789,7 +1784,7 @@ module Make (Config : CONFIG) = struct
                   (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err))))
               with e ->
                 on_result (Error (Error_types.Internal_error (Printf.sprintf "Failed to parse user ID: %s" (Printexc.to_string e))))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Unmute a user *)
   let unmute_user ~account_id ~target_user_id on_result =
@@ -1819,7 +1814,7 @@ module Make (Config : CONFIG) = struct
                   (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err))))
               with e ->
                 on_result (Error (Error_types.Internal_error (Printf.sprintf "Failed to parse user ID: %s" (Printexc.to_string e))))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Get followers of a user *)
   let get_followers ~account_id ~user_id ?(max_results=100) ?(pagination_token=None) ?(user_fields=[]) () on_result =
@@ -1852,7 +1847,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Get users that a user is following *)
   let get_following ~account_id ~user_id ?(max_results=100) ?(pagination_token=None) ?(user_fields=[]) () on_result =
@@ -1885,7 +1880,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Search for users by keyword *)
   let search_users ~account_id ~query ?(max_results=100) ?(pagination_token=None) ?(user_fields=[]) () on_result =
@@ -1919,7 +1914,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Like a tweet *)
   let like_tweet ~account_id ~tweet_id on_result =
@@ -1952,7 +1947,7 @@ module Make (Config : CONFIG) = struct
                   (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err))))
               with e ->
                 on_result (Error (Error_types.Internal_error (Printf.sprintf "Failed to parse user ID: %s" (Printexc.to_string e))))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Unlike a tweet *)
   let unlike_tweet ~account_id ~tweet_id on_result =
@@ -1982,7 +1977,7 @@ module Make (Config : CONFIG) = struct
                   (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err))))
               with e ->
                 on_result (Error (Error_types.Internal_error (Printf.sprintf "Failed to parse user ID: %s" (Printexc.to_string e))))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Retweet a tweet *)
   let retweet ~account_id ~tweet_id on_result =
@@ -2015,7 +2010,7 @@ module Make (Config : CONFIG) = struct
                   (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err))))
               with e ->
                 on_result (Error (Error_types.Internal_error (Printf.sprintf "Failed to parse user ID: %s" (Printexc.to_string e))))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Unretweet (delete retweet) *)
   let unretweet ~account_id ~tweet_id on_result =
@@ -2045,7 +2040,7 @@ module Make (Config : CONFIG) = struct
                   (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err))))
               with e ->
                 on_result (Error (Error_types.Internal_error (Printf.sprintf "Failed to parse user ID: %s" (Printexc.to_string e))))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Quote tweet (tweet with quoted tweet reference) *)
   let quote_tweet ~account_id ~text ~quoted_tweet_id ~media_urls on_success on_error =
@@ -2128,7 +2123,7 @@ module Make (Config : CONFIG) = struct
                       on_error (Printf.sprintf "Failed to quote tweet (%d): %s" response.status response.body))
                   on_error)
               on_error)
-          on_error
+          (fun err -> on_error (Error_types.error_to_string err))
   
   (** Reply to a tweet *)
   let reply_to_tweet ~account_id ~text ~reply_to_tweet_id ~media_urls on_success on_error =
@@ -2210,7 +2205,7 @@ module Make (Config : CONFIG) = struct
                       on_error (Printf.sprintf "Failed to reply to tweet (%d): %s" response.status response.body))
                   on_error)
               on_error)
-          on_error
+          (fun err -> on_error (Error_types.error_to_string err))
   
   (** Bookmark a tweet *)
   let bookmark_tweet ~account_id ~tweet_id on_result =
@@ -2243,7 +2238,7 @@ module Make (Config : CONFIG) = struct
                   (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err))))
               with e ->
                 on_result (Error (Error_types.Internal_error (Printf.sprintf "Failed to parse user ID: %s" (Printexc.to_string e))))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Remove bookmark from a tweet *)
   let remove_bookmark ~account_id ~tweet_id on_result =
@@ -2273,7 +2268,7 @@ module Make (Config : CONFIG) = struct
                   (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err))))
               with e ->
                 on_result (Error (Error_types.Internal_error (Printf.sprintf "Failed to parse user ID: %s" (Printexc.to_string e))))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Create a list *)
   let create_list ~account_id ~name ?(description=None) ?(private_list=false) () on_result =
@@ -2308,7 +2303,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Update a list *)
   let update_list ~account_id ~list_id ?(name=None) ?(description=None) ?(private_list=None) () on_result =
@@ -2352,7 +2347,7 @@ module Make (Config : CONFIG) = struct
               else
                 on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
             (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Delete a list *)
   let delete_list ~account_id ~list_id on_result =
@@ -2381,7 +2376,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Get a list by ID *)
   let get_list ~account_id ~list_id ?(list_fields=[]) () on_result =
@@ -2411,7 +2406,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Add a member to a list *)
   let add_list_member ~account_id ~list_id ~user_id on_result =
@@ -2433,7 +2428,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Remove a member from a list *)
   let remove_list_member ~account_id ~list_id ~user_id on_result =
@@ -2451,7 +2446,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Get list members *)
   let get_list_members ~account_id ~list_id ?(max_results=100) ?(pagination_token=None) ?(user_fields=[]) () on_result =
@@ -2484,7 +2479,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Follow a list *)
   let follow_list ~account_id ~list_id on_success on_error =
@@ -2518,7 +2513,7 @@ module Make (Config : CONFIG) = struct
                   on_error
               with e ->
                 on_error (Printf.sprintf "Failed to parse user ID: %s" (Printexc.to_string e))))
-      on_error
+      (fun err -> on_error (Error_types.error_to_string err))
   
   (** Unfollow a list *)
   let unfollow_list ~account_id ~list_id on_success on_error =
@@ -2548,7 +2543,7 @@ module Make (Config : CONFIG) = struct
                   on_error
               with e ->
                 on_error (Printf.sprintf "Failed to parse user ID: %s" (Printexc.to_string e))))
-      on_error
+      (fun err -> on_error (Error_types.error_to_string err))
   
   (** Get tweets from a list *)
   let get_list_tweets ~account_id ~list_id ?(max_results=100) ?(pagination_token=None) ?(expansions=[]) ?(tweet_fields=[]) () on_result =
@@ -2584,7 +2579,7 @@ module Make (Config : CONFIG) = struct
             else
               on_result (Error (parse_api_error ~status_code:response.status ~body:response.body)))
           (fun err -> on_result (Error (Error_types.Network_error (Error_types.Connection_failed err)))))
-      (fun err -> on_result (Error (Error_types.Auth_error (Error_types.Refresh_failed err))))
+      (fun err -> on_result (Error err))
   
   (** Pin a list for authenticated user *)
   let pin_list ~account_id ~list_id on_success on_error =
@@ -2618,7 +2613,7 @@ module Make (Config : CONFIG) = struct
                   on_error
               with e ->
                 on_error (Printf.sprintf "Failed to parse user ID: %s" (Printexc.to_string e))))
-      on_error
+      (fun err -> on_error (Error_types.error_to_string err))
   
   (** Unpin a list for authenticated user *)
   let unpin_list ~account_id ~list_id on_success on_error =
@@ -2648,7 +2643,7 @@ module Make (Config : CONFIG) = struct
                   on_error
               with e ->
                 on_error (Printf.sprintf "Failed to parse user ID: %s" (Printexc.to_string e))))
-      on_error
+      (fun err -> on_error (Error_types.error_to_string err))
   
   (** Validate content for Twitter *)
   let validate_content ~text =

--- a/packages/social-youtube-data-v3/lib/youtube_data_v3.ml
+++ b/packages/social-youtube-data-v3/lib/youtube_data_v3.ml
@@ -491,8 +491,8 @@ module Make (Config : CONFIG) = struct
           | None ->
               Config.update_health_status ~account_id ~status:"token_expired" 
                 ~error_message:(Some "No refresh token available")
-                (fun () -> on_error "No refresh token available - please reconnect")
-                on_error
+                (fun () -> on_error (Error_types.Auth_error Error_types.Missing_credentials))
+                (fun _ -> on_error (Error_types.Auth_error Error_types.Missing_credentials))
           | Some refresh_token ->
               let client_id = Config.get_env "YOUTUBE_CLIENT_ID" |> Option.value ~default:"" in
               let client_secret = Config.get_env "YOUTUBE_CLIENT_SECRET" |> Option.value ~default:"" in
@@ -510,19 +510,19 @@ module Make (Config : CONFIG) = struct
                     (fun () ->
                       Config.update_health_status ~account_id ~status:"healthy" ~error_message:None
                         (fun () -> on_success new_access)
-                        on_error)
-                    on_error)
+                        (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
+                    (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
                 (fun err ->
                   Config.update_health_status ~account_id ~status:"refresh_failed" 
                     ~error_message:(Some err)
-                    (fun () -> on_error err)
-                    on_error)
+                    (fun () -> on_error (Error_types.Auth_error (Error_types.Refresh_failed err)))
+                    (fun _ -> on_error (Error_types.Auth_error (Error_types.Refresh_failed err))))
         else
           (* Token still valid *)
           Config.update_health_status ~account_id ~status:"healthy" ~error_message:None
             (fun () -> on_success creds.access_token)
-            on_error)
-      on_error
+            (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err))))
+      (fun err -> on_error (Error_types.Network_error (Error_types.Connection_failed err)))
   
   (** Upload video to YouTube Shorts *)
   let post_single ~account_id ~text ~media_urls ?(alt_texts=[]) on_result =
@@ -603,7 +603,7 @@ module Make (Config : CONFIG) = struct
                 else
                   on_result (Error_types.Failure (Error_types.Internal_error (Printf.sprintf "Failed to download video (%d)" video_response.status))))
               (fun err -> on_result (Error_types.Failure (Error_types.Internal_error err))))
-          (fun err -> on_result (Error_types.Failure (Error_types.Auth_error (Error_types.Refresh_failed err))))
+          (fun err -> on_result (Error_types.Failure err))
   
   (** Post thread (YouTube doesn't support threads, posts only first item) *)
   let post_thread ~account_id ~texts ~media_urls_per_post ?(alt_texts_per_post=[]) on_result =

--- a/packages/social-youtube-data-v3/test/test_youtube.ml
+++ b/packages/social-youtube-data-v3/test/test_youtube.ml
@@ -235,7 +235,7 @@ let test_ensure_valid_token_fresh () =
     (fun token ->
       assert (token = "valid_token");
       print_endline "✓ Ensure valid token (fresh)")
-    (fun err -> failwith ("Ensure valid token failed: " ^ err))
+    (fun err -> failwith ("Ensure valid token failed: " ^ Error_types.error_to_string err))
 
 (** Test: Ensure valid token (expired, needs refresh) *)
 let test_ensure_valid_token_expired () =
@@ -272,7 +272,7 @@ let test_ensure_valid_token_expired () =
     (fun token ->
       assert (token = "refreshed_token");
       print_endline "✓ Ensure valid token (auto-refresh)")
-    (fun err -> failwith ("Ensure valid token failed: " ^ err))
+    (fun err -> failwith ("Ensure valid token failed: " ^ Error_types.error_to_string err))
 
 (** Test: Post requires video *)
 let test_post_requires_video () =


### PR DESCRIPTION
## Summary

- Standardizes the `ensure_valid_token` function across all 8 providers to use `Error_types.error` for the `on_error` callback, matching Bluesky's correct implementation
- Ensures consistent error handling semantics: `Auth_error Token_expired` for expired tokens, `Auth_error Missing_credentials` for missing refresh tokens, `Network_error Connection_failed` for credential retrieval failures

## Details

Previously, only Bluesky used the correct typed error approach while all other providers used raw strings:

```ocaml
(* Before - inconsistent string-based *)
let ensure_valid_token ~account_id on_success on_error =
  ... on_error "Token expired"

(* After - consistent Error_types.error *)
let ensure_valid_token ~account_id on_success on_error =
  ... on_error (Error_types.Auth_error Error_types.Token_expired)
```

### Providers Updated
- Pinterest v5
- YouTube Data v3
- TikTok v1
- Facebook Graph v21
- Instagram Graph v21
- Mastodon v1
- LinkedIn v2
- Twitter v2

### Additional Fixes
- Updated Mastodon's `delete_status` and `edit_status` functions to also use typed errors for consistency
- Updated all call sites to pass errors directly instead of wrapping them

Fixes #26